### PR TITLE
Update APTSimulator.bat

### DIFF
--- a/APTSimulator.bat
+++ b/APTSimulator.bat
@@ -6,7 +6,8 @@ ECHO   APT Simulator
 ECHO   Florian Roth, v0.4.1 February 2018
 ECHO ===========================================================================
 
-SET CWD=%CD%
+SET CWD="%~dp0"
+cd %CWD%
 
 :: Config
 SET ZIP=%CWD%\helpers\7z.exe


### PR DESCRIPTION
When I running cmd.exe as Administrator the value %CD% is "C:\WINDOWS\system32>"
Use "%~dp0" to get a real current directory.