### PR TITLE
Update to latest powercat

### DIFF
--- a/toolset/nc.ps1
+++ b/toolset/nc.ps1
@@ -169,7 +169,7 @@ Examples:
       {
         if($Host.UI.RawUI.KeyAvailable)
         {
-          if(@(17,27) -contains ($Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown").VirtualKeyCode))
+          if(@(17,27) -contains ($Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown,IncludeKeyUp").VirtualKeyCode))
           {
             Write-Verbose "CTRL or ESC caught. Stopping UDP Setup..."
             $FuncVars["Socket"].Close()
@@ -451,7 +451,7 @@ Examples:
     {
       if($Host.UI.RawUI.KeyAvailable)
       {
-        if(@(17,27) -contains ($Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown").VirtualKeyCode))
+        if(@(17,27) -contains ($Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown,IncludeKeyUp").VirtualKeyCode))
         {
           Write-Verbose "CTRL or ESC caught. Stopping TCP Setup..."
           if($FuncVars["l"]){$Socket.Stop()}


### PR DESCRIPTION
The existing older powercat call in test-sets\command-and-control\netcat-back-connect.bat does not return and stalls the simulator.
The issue appears to be https://github.com/besimorhino/powercat/issues/19, which is addressed in the latest version.
Using the latest version powercat returns on my Win10 system and the simulator can continue.